### PR TITLE
Feature/implement auth rsa keys correct generation and save

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 build/
+/keys/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/infrastructure/src/main/java/com/kaua/events/platform/infrastructure/configurations/RSAKeyProviderConfig.java
+++ b/infrastructure/src/main/java/com/kaua/events/platform/infrastructure/configurations/RSAKeyProviderConfig.java
@@ -1,0 +1,20 @@
+package com.kaua.events.platform.infrastructure.configurations;
+
+import com.kaua.events.platform.infrastructure.services.rsakey.FileRsaKeyProvider;
+import com.kaua.events.platform.infrastructure.services.rsakey.RsaKeyProvider;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.nio.file.Path;
+
+@Configuration(proxyBeanMethods = false)
+public class RSAKeyProviderConfig {
+
+    @Profile("!test-integration")
+    @Bean
+    public RsaKeyProvider rsaKeyProvider(@Value("${application.rsa.key.path}") Path keyPath) {
+        return new FileRsaKeyProvider(keyPath);
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/events/platform/infrastructure/configurations/SecurityConfig.java
+++ b/infrastructure/src/main/java/com/kaua/events/platform/infrastructure/configurations/SecurityConfig.java
@@ -2,10 +2,10 @@ package com.kaua.events.platform.infrastructure.configurations;
 
 import com.kaua.events.platform.infrastructure.configurations.authentication.JwtConverter;
 import com.kaua.events.platform.infrastructure.configurations.properties.CorsProperties;
-import com.nimbusds.jose.JOSEException;
+import com.kaua.events.platform.infrastructure.constants.Constants;
+import com.kaua.events.platform.infrastructure.services.rsakey.RsaKeyProvider;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.RSAKey;
-import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -26,7 +26,6 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Objects;
 
@@ -55,31 +54,20 @@ public class SecurityConfig {
     }
 
     @Bean
-    public JwtDecoder jwtDecoder() {
-        // TODO: Change this to a real public key
-        RSAKeyGenerator rsaKeyGenerator = new RSAKeyGenerator(2048);
-        try {
-            RSAKey rsaKey = rsaKeyGenerator.generate();
-            return NimbusJwtDecoder.withPublicKey(rsaKey.toRSAPublicKey()).build();
-        } catch (JOSEException e) {
-            throw new RuntimeException(e);
-        }
+    public JwtDecoder jwtDecoder(RsaKeyProvider rsaKeyProvider) {
+        return NimbusJwtDecoder
+                .withPublicKey(rsaKeyProvider.getPublicKey(Constants.JWT_RSA_KEY_NAME))
+                .build();
     }
 
     @Bean
-    public JwtEncoder jwtEncoder() {
-        // TODO: Change this to get real public and private keys
-        RSAKeyGenerator rsaKeyGenerator = new RSAKeyGenerator(2048);
-        RSAKey jwk = null;
-        try {
-            RSAKey rsaKey = rsaKeyGenerator.generate();
-            jwk = new RSAKey.Builder(rsaKey.toRSAPublicKey())
-                    .privateKey(rsaKey.toPrivateKey()).build();
-        } catch (JOSEException e) {
-            throw new RuntimeException(e);
-        }
+    public JwtEncoder jwtEncoder(RsaKeyProvider rsaKeyProvider) {
+        RSAKey jwk = new RSAKey.Builder(
+                rsaKeyProvider.getPublicKey(Constants.JWT_RSA_KEY_NAME))
+                .privateKey(rsaKeyProvider.getPrivateKey(Constants.JWT_RSA_KEY_NAME))
+                .build();
 
-        var jkws = new ImmutableJWKSet<>(new JWKSet(jwk));
+        final var jkws = new ImmutableJWKSet<>(new JWKSet(jwk));
 
         return new NimbusJwtEncoder(jkws);
     }

--- a/infrastructure/src/main/java/com/kaua/events/platform/infrastructure/constants/Constants.java
+++ b/infrastructure/src/main/java/com/kaua/events/platform/infrastructure/constants/Constants.java
@@ -1,0 +1,10 @@
+package com.kaua.events.platform.infrastructure.constants;
+
+public final class Constants {
+
+    public static final String JWT_RSA_KEY_NAME = "jwt";
+    public static final String RSA_KEY_PUBLIC_FILE = "-public.pem";
+    public static final String RSA_KEY_PRIVATE_FILE = "-private.pem";
+
+    private Constants() {}
+}

--- a/infrastructure/src/main/java/com/kaua/events/platform/infrastructure/services/rsakey/FileRsaKeyProvider.java
+++ b/infrastructure/src/main/java/com/kaua/events/platform/infrastructure/services/rsakey/FileRsaKeyProvider.java
@@ -1,0 +1,71 @@
+package com.kaua.events.platform.infrastructure.services.rsakey;
+
+import com.kaua.events.platform.infrastructure.constants.Constants;
+import com.kaua.events.platform.infrastructure.utils.PemFileUtils;
+import com.kaua.events.platform.infrastructure.utils.RsaKeyPair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class FileRsaKeyProvider implements RsaKeyProvider {
+
+    private static final Logger log = LoggerFactory.getLogger(FileRsaKeyProvider.class);
+
+    private final Path basePath;
+    private final Map<String, RsaKeyPair> keyPairs = new ConcurrentHashMap<>();
+
+    public FileRsaKeyProvider(final Path basePath) {
+        this.basePath = Objects.requireNonNull(basePath);
+        createBasePathIfNotExists();
+    }
+
+    /*
+     * @Param keyName - The name of the key to load.
+     * @Return - The private key.
+     * @Example - If the key name is "mykey", the private key will be loaded from, does not send this "mykey-public.pem"
+     * */
+    @Override
+    public RSAPrivateKey getPrivateKey(final String keyName) {
+        log.debug("Loading private key for: {}", keyName);
+        return keyPairs.computeIfAbsent(keyName, name -> {
+            Path path = basePath.resolve(name + Constants.RSA_KEY_PRIVATE_FILE);
+            log.debug("Loading private key from: {}", path);
+            return PemFileUtils.readOrCreateKeyPair(path);
+        }).privateKey();
+    }
+
+    /*
+     * @Param keyName - The name of the key to load.
+     * @Return - The public key.
+     * @Example - If the key name is "mykey", the public key will be loaded from, does not send this "mykey-public.pem"
+     * */
+    @Override
+    public RSAPublicKey getPublicKey(final String keyName) {
+        log.debug("Loading public key for: {}", keyName);
+        return keyPairs.computeIfAbsent(keyName, name -> {
+            Path path = basePath.resolve(name + Constants.RSA_KEY_PUBLIC_FILE);
+            log.debug("Loading public key from: {}", path);
+            return PemFileUtils.readOrCreateKeyPair(path);
+        }).publicKey();
+    }
+
+    private void createBasePathIfNotExists() {
+        try {
+            if (!Files.exists(basePath)) {
+                Files.createDirectories(basePath);
+                log.debug("Created missing base path directory: {}", basePath);
+            }
+        } catch (IOException e) {
+            log.error("Could not create base path: {}", basePath, e);
+            throw new RuntimeException("Could not create base path: " + basePath, e);
+        }
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/events/platform/infrastructure/services/rsakey/RsaKeyProvider.java
+++ b/infrastructure/src/main/java/com/kaua/events/platform/infrastructure/services/rsakey/RsaKeyProvider.java
@@ -1,0 +1,10 @@
+package com.kaua.events.platform.infrastructure.services.rsakey;
+
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+
+public interface RsaKeyProvider {
+
+    RSAPrivateKey getPrivateKey(String keyName);
+    RSAPublicKey getPublicKey(String keyName);
+}

--- a/infrastructure/src/main/java/com/kaua/events/platform/infrastructure/utils/PemFileUtils.java
+++ b/infrastructure/src/main/java/com/kaua/events/platform/infrastructure/utils/PemFileUtils.java
@@ -1,0 +1,103 @@
+package com.kaua.events.platform.infrastructure.utils;
+
+import com.kaua.events.platform.infrastructure.constants.Constants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Base64;
+
+public final class PemFileUtils {
+
+    private static final Logger log = LoggerFactory.getLogger(PemFileUtils.class);
+
+    private static final int KEY_SIZE = 2048;
+    private static final String RSA = "RSA";
+
+    private PemFileUtils() {
+    }
+
+    public static RsaKeyPair readOrCreateKeyPair(Path keyPath) {
+        try {
+            String keyBaseName = getBaseKeyName(keyPath);
+            Path directory = keyPath.getParent();
+            Path privatePath = directory.resolve(keyBaseName + Constants.RSA_KEY_PRIVATE_FILE);
+            Path publicPath = directory.resolve(keyBaseName + Constants.RSA_KEY_PUBLIC_FILE);
+
+            if (Files.notExists(privatePath) || Files.notExists(publicPath)) {
+                log.info("Generating new RSA key pair: {}", keyBaseName);
+                generateAndWriteKeyPair(privatePath, publicPath);
+            }
+
+            log.debug("Loading RSA keys: {} / {}", privatePath.getFileName(), publicPath.getFileName());
+            RSAPrivateKey privateKey = readPrivateKey(privatePath);
+            RSAPublicKey publicKey = readPublicKey(publicPath);
+            return new RsaKeyPair(privateKey, publicKey);
+
+        } catch (Exception e) {
+            throw new UncheckedIOException(new IOException("Failed to load/create RSA key pair from path: " + keyPath, e));
+        }
+    }
+
+    private static RSAPrivateKey readPrivateKey(Path path) throws Exception {
+        byte[] decoded = decodePem(Files.readString(path), "PRIVATE KEY");
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(decoded);
+        return (RSAPrivateKey) KeyFactory.getInstance(RSA).generatePrivate(keySpec);
+    }
+
+    private static RSAPublicKey readPublicKey(Path path) throws Exception {
+        byte[] decoded = decodePem(Files.readString(path), "PUBLIC KEY");
+        X509EncodedKeySpec keySpec = new X509EncodedKeySpec(decoded);
+        return (RSAPublicKey) KeyFactory.getInstance(RSA).generatePublic(keySpec);
+    }
+
+    private static byte[] decodePem(String pem, String type) {
+        String clean = pem.replace("-----BEGIN " + type + "-----", "")
+                .replace("-----END " + type + "-----", "")
+                .replaceAll("\\s", "");
+        return Base64.getDecoder().decode(clean);
+    }
+
+    private static void generateAndWriteKeyPair(Path privatePath, Path publicPath) throws Exception {
+        KeyPairGenerator gen = KeyPairGenerator.getInstance(RSA);
+        gen.initialize(KEY_SIZE);
+        KeyPair pair = gen.generateKeyPair();
+
+        writePem(privatePath, "PRIVATE KEY", pair.getPrivate().getEncoded());
+        writePem(publicPath, "PUBLIC KEY", pair.getPublic().getEncoded());
+    }
+
+    private static void writePem(Path path, String type, byte[] encoded) throws IOException {
+        String base64 = Base64.getEncoder().encodeToString(encoded);
+        String pem = "-----BEGIN " + type + "-----\n" +
+                chunk(base64, 64) +
+                "-----END " + type + "-----\n";
+
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, pem, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    private static String chunk(String data, int size) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < data.length(); i += size) {
+            sb.append(data, i, Math.min(i + size, data.length())).append('\n');
+        }
+        return sb.toString();
+    }
+
+    private static String getBaseKeyName(Path path) {
+        String name = path.getFileName().toString();
+        return name.replace(Constants.RSA_KEY_PRIVATE_FILE, "").replace(Constants.RSA_KEY_PUBLIC_FILE, "").replace(".pem", "");
+    }
+}

--- a/infrastructure/src/main/java/com/kaua/events/platform/infrastructure/utils/RsaKeyPair.java
+++ b/infrastructure/src/main/java/com/kaua/events/platform/infrastructure/utils/RsaKeyPair.java
@@ -1,0 +1,7 @@
+package com.kaua.events.platform.infrastructure.utils;
+
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+
+public record RsaKeyPair(RSAPrivateKey privateKey, RSAPublicKey publicKey) {
+}

--- a/infrastructure/src/main/resources/application.yml
+++ b/infrastructure/src/main/resources/application.yml
@@ -9,6 +9,9 @@ application:
       - "Content-Type"
     allow-credentials: true
     max-age-preflight: 3600 # 1 hour
+  rsa:
+    key:
+      path: ./keys/
 
 idempotency-key:
   storage:

--- a/infrastructure/src/main/resources/logback-test.xml
+++ b/infrastructure/src/main/resources/logback-test.xml
@@ -1,0 +1,39 @@
+<configuration>
+    <import class="ch.qos.logback.core.ConsoleAppender" />
+    <import class="ch.qos.logback.core.FileAppender" />
+    <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder" />
+
+    <statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" />
+
+    <appender name="OTEL" class="io.opentelemetry.instrumentation.logback.appender.v1_0.OpenTelemetryAppender">
+        <captureExperimentalAttributes>true</captureExperimentalAttributes>
+        <captureCodeAttributes>true</captureCodeAttributes>
+        <captureMarkerAttribute>true</captureMarkerAttribute>
+        <captureKeyValuePairAttributes>true</captureKeyValuePairAttributes>
+        <captureMdcAttributes>*</captureMdcAttributes>
+    </appender>
+
+    <appender name="stdout_plain" class="ConsoleAppender">
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder"> <!-- https://www.codelord.net/2010/08/27/logging-with-a-context-users-in-logback-and-spring-security/ -->
+            <layout class="com.kaua.events.platform.infrastructure.configurations.logback.PatternLayoutWithAttributes">
+                <pattern> <!-- https://github.com/onready/demo-spring-security-logging-pattern -->
+                    %d{HH:mm:ss.SSSZZ} [%thread] [%X{traceId}] [%X{spanId}] [%user] %-5level %logger{36} - %msg%n
+                </pattern>
+            </layout>
+        </encoder>
+    </appender>
+
+    <logger name="ch.qos.logback" level="WARN" />
+    <logger name="org.mortbay.log" level="WARN" />
+    <logger name="org.springframework" level="INFO" />
+    <logger name="org.springframework.beans" level="WARN" />
+
+    <!-- enable DEBUG only for the application -->
+    <logger name="store" level="DEBUG" />
+    <logger name="com.kaua.events.platform" level="DEBUG" />
+
+    <root level="INFO">
+        <appender-ref ref="OTEL" />
+        <appender-ref ref="stdout_plain" />
+    </root>
+</configuration>

--- a/infrastructure/src/test/java/com/kaua/events/platform/ControllerTest.java
+++ b/infrastructure/src/test/java/com/kaua/events/platform/ControllerTest.java
@@ -14,7 +14,7 @@ import java.lang.annotation.*;
 @Inherited
 @ActiveProfiles("test-integration")
 @WebMvcTest
-@Import(SecurityConfig.class)
+@Import({ SecurityConfig.class, IntegrationTestConfig.class })
 @Tag("integrationTest")
 public @interface ControllerTest {
 

--- a/infrastructure/src/test/java/com/kaua/events/platform/IntegrationTest.java
+++ b/infrastructure/src/test/java/com/kaua/events/platform/IntegrationTest.java
@@ -12,7 +12,8 @@ import java.lang.annotation.*;
 @Inherited
 @ActiveProfiles("test-integration")
 @SpringBootTest(classes = {
-        WebServerConfig.class
+        WebServerConfig.class,
+        IntegrationTestConfig.class
 })
 @Tag("integrationTest")
 public @interface IntegrationTest {

--- a/infrastructure/src/test/java/com/kaua/events/platform/IntegrationTestConfig.java
+++ b/infrastructure/src/test/java/com/kaua/events/platform/IntegrationTestConfig.java
@@ -1,0 +1,51 @@
+package com.kaua.events.platform;
+
+import com.kaua.events.platform.infrastructure.services.rsakey.RsaKeyProvider;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Configuration(proxyBeanMethods = false)
+public class IntegrationTestConfig {
+
+//    @Profile("test")
+    @Bean
+    public RsaKeyProvider rsaKeyProviderTest() {
+        return new InMemoryRsaKeyProvider();
+    }
+
+    public static class InMemoryRsaKeyProvider implements RsaKeyProvider {
+
+        private final Map<String, KeyPair> keyPairs = new ConcurrentHashMap<>();
+
+        @Override
+        public RSAPrivateKey getPrivateKey(String keyName) {
+            return (RSAPrivateKey) getOrCreateKeyPair(keyName).getPrivate();
+        }
+
+        @Override
+        public RSAPublicKey getPublicKey(String keyName) {
+            return (RSAPublicKey) getOrCreateKeyPair(keyName).getPublic();
+        }
+
+        private KeyPair getOrCreateKeyPair(String keyName) {
+            return keyPairs.computeIfAbsent(keyName, __ -> {
+                try {
+                    KeyPairGenerator generator = KeyPairGenerator.getInstance("RSA");
+                    generator.initialize(2048);
+                    return generator.generateKeyPair();
+                } catch (Exception e) {
+                    throw new RuntimeException("Failed to generate RSA key pair for test", e);
+                }
+            });
+        }
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/events/platform/infrastructure/idempotency/IdempotencyKeyFilterTest.java
+++ b/infrastructure/src/test/java/com/kaua/events/platform/infrastructure/idempotency/IdempotencyKeyFilterTest.java
@@ -16,15 +16,23 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.HandlerExecutionChain;
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
 
+import java.lang.reflect.Method;
+
 import static com.kaua.events.platform.ApiTest.admin;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @IntegrationTest
 @AutoConfigureMockMvc
@@ -58,7 +66,7 @@ public class IdempotencyKeyFilterTest {
 
         this.mvc.perform(request)
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(status().isCreated())
                 .andExpect(MockMvcResultMatchers.header().string("Location", "/test/idempotency-key-helper/" + aId))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(aId));
     }
@@ -76,7 +84,7 @@ public class IdempotencyKeyFilterTest {
 
         this.mvc.perform(request)
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(status().isCreated())
                 .andExpect(MockMvcResultMatchers.header().string("Location", "/test/idempotency-key-helper/" + "&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.id").value("&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;"));
     }
@@ -97,7 +105,7 @@ public class IdempotencyKeyFilterTest {
 
         this.mvc.perform(aFirstRequest)
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(status().isCreated())
                 .andExpect(MockMvcResultMatchers.header().string("Location", "/test/idempotency-key-helper/" + aId))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(aId));
 
@@ -110,7 +118,7 @@ public class IdempotencyKeyFilterTest {
 
         this.mvc.perform(request)
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isCreated())
+                .andExpect(status().isCreated())
                 .andExpect(MockMvcResultMatchers.header().string("Location", "/test/idempotency-key-helper/" + aId))
                 .andExpect(MockMvcResultMatchers.header().string("x-idempotency-response", "true"))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(aId));
@@ -127,7 +135,7 @@ public class IdempotencyKeyFilterTest {
 
         this.mvc.perform(request)
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(aId));
     }
 
@@ -146,7 +154,7 @@ public class IdempotencyKeyFilterTest {
 
         this.mvc.perform(request)
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(aId));
     }
 
@@ -165,7 +173,7 @@ public class IdempotencyKeyFilterTest {
 
         this.mvc.perform(request)
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(aId));
     }
 
@@ -183,7 +191,7 @@ public class IdempotencyKeyFilterTest {
 
         this.mvc.perform(request)
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(aId));
     }
 
@@ -201,7 +209,7 @@ public class IdempotencyKeyFilterTest {
 
         this.mvc.perform(request)
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isUnprocessableEntity())
+                .andExpect(status().isUnprocessableEntity())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("Idempotency key required and the required header is 'x-idempotency-key'"));
     }
 
@@ -216,18 +224,18 @@ public class IdempotencyKeyFilterTest {
 
         this.mvc.perform(request)
                 .andDo(MockMvcResultHandlers.print())
-                .andExpect(MockMvcResultMatchers.status().isMethodNotAllowed())
+                .andExpect(status().isMethodNotAllowed())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.message").value("Idempotency key is not supported for this method: GET"));
     }
 
     @Test
     void testOnHandlerMethodThrows() throws Exception {
-        final var aRequest = Mockito.mock(HttpServletRequest.class);
-        final var aResponse = Mockito.mock(HttpServletResponse.class);
-        final var aFilterChain = Mockito.mock(FilterChain.class);
+        final var aRequest = mock(HttpServletRequest.class);
+        final var aResponse = mock(HttpServletResponse.class);
+        final var aFilterChain = mock(FilterChain.class);
 
         final var aHandlerExceptionResolver = Mockito.spy(HandlerExceptionResolver.class);
-        final var aRequestMappingHandlerMapping = Mockito.mock(RequestMappingHandlerMapping.class);
+        final var aRequestMappingHandlerMapping = mock(RequestMappingHandlerMapping.class);
 
         final var aIdempotencyKeyFilter = new IdempotencyKeyFilter(
                 idempotencyKeyGateway,
@@ -236,7 +244,7 @@ public class IdempotencyKeyFilterTest {
                 observationHelper
         );
 
-        Mockito.when(aRequestMappingHandlerMapping.getHandler(Mockito.any()))
+        when(aRequestMappingHandlerMapping.getHandler(Mockito.any()))
                 .thenThrow(new RuntimeException("test"));
 
         aIdempotencyKeyFilter.doFilterInternal(aRequest, aResponse, aFilterChain);
@@ -247,12 +255,12 @@ public class IdempotencyKeyFilterTest {
 
     @Test
     void testOnHandlerMethodReturnsNull() throws Exception {
-        final var aRequest = Mockito.mock(HttpServletRequest.class);
-        final var aResponse = Mockito.mock(HttpServletResponse.class);
-        final var aFilterChain = Mockito.mock(FilterChain.class);
+        final var aRequest = mock(HttpServletRequest.class);
+        final var aResponse = mock(HttpServletResponse.class);
+        final var aFilterChain = mock(FilterChain.class);
 
         final var aHandlerExceptionResolver = Mockito.spy(HandlerExceptionResolver.class);
-        final var aRequestMappingHandlerMapping = Mockito.mock(RequestMappingHandlerMapping.class);
+        final var aRequestMappingHandlerMapping = mock(RequestMappingHandlerMapping.class);
 
         final var aIdempotencyKeyFilter = new IdempotencyKeyFilter(
                 idempotencyKeyGateway,
@@ -261,7 +269,7 @@ public class IdempotencyKeyFilterTest {
                 observationHelper
         );
 
-        Mockito.when(aRequestMappingHandlerMapping.getHandler(aRequest))
+        when(aRequestMappingHandlerMapping.getHandler(aRequest))
                 .thenReturn(null);
 
         Assertions.assertDoesNotThrow(() -> aIdempotencyKeyFilter.doFilterInternal(aRequest, aResponse, aFilterChain));
@@ -269,12 +277,12 @@ public class IdempotencyKeyFilterTest {
 
     @Test
     void testOnHandlerMethodIsNotHandlerMethod() throws Exception {
-        final var aRequest = Mockito.mock(HttpServletRequest.class);
-        final var aResponse = Mockito.mock(HttpServletResponse.class);
-        final var aFilterChain = Mockito.mock(FilterChain.class);
+        final var aRequest = mock(HttpServletRequest.class);
+        final var aResponse = mock(HttpServletResponse.class);
+        final var aFilterChain = mock(FilterChain.class);
 
         final var aHandlerExceptionResolver = Mockito.spy(HandlerExceptionResolver.class);
-        final var aRequestMappingHandlerMapping = Mockito.mock(RequestMappingHandlerMapping.class);
+        final var aRequestMappingHandlerMapping = mock(RequestMappingHandlerMapping.class);
 
         final var aIdempotencyKeyFilter = new IdempotencyKeyFilter(
                 idempotencyKeyGateway,
@@ -283,11 +291,133 @@ public class IdempotencyKeyFilterTest {
                 observationHelper
         );
 
-        final var aHandlerExecutionChain = Mockito.mock(HandlerExecutionChain.class);
+        final var aHandlerExecutionChain = mock(HandlerExecutionChain.class);
 
-        Mockito.when(aRequestMappingHandlerMapping.getHandler(aRequest))
+        when(aRequestMappingHandlerMapping.getHandler(aRequest))
                 .thenReturn(aHandlerExecutionChain);
 
         Assertions.assertDoesNotThrow(() -> aIdempotencyKeyFilter.doFilterInternal(aRequest, aResponse, aFilterChain));
+    }
+
+    @Test
+    void testOnHandlerMethodReturnsValidHandlerMethod() throws Exception {
+        final var aRequest = mock(HttpServletRequest.class);
+        final var aHandlerExceptionResolver = mock(HandlerExceptionResolver.class);
+        final var aRequestMappingHandlerMapping = mock(RequestMappingHandlerMapping.class);
+        final var aHandlerMethod = mock(HandlerMethod.class);
+
+        final var aHandlerChain = new HandlerExecutionChain(aHandlerMethod);
+
+        when(aRequestMappingHandlerMapping.getHandler(Mockito.any()))
+                .thenReturn(aHandlerChain);
+
+        final var aIdempotencyKeyFilter = new IdempotencyKeyFilter(
+                idempotencyKeyGateway,
+                aRequestMappingHandlerMapping,
+                aHandlerExceptionResolver,
+                observationHelper
+        );
+
+        var method = IdempotencyKeyFilter.class.getDeclaredMethod("getHandlerMethod", HttpServletRequest.class);
+        method.setAccessible(true);
+        var result = method.invoke(aIdempotencyKeyFilter, aRequest);
+
+        Assertions.assertEquals(aHandlerMethod, result);
+    }
+
+    @Test
+    void testOnHandlerMethodReturnsHandlerChainButNotHandlerMethod() throws Exception {
+        final var aRequest = mock(HttpServletRequest.class);
+        final var aHandlerExceptionResolver = mock(HandlerExceptionResolver.class);
+        final var aRequestMappingHandlerMapping = mock(RequestMappingHandlerMapping.class);
+
+        final var someOtherHandler = new Object();
+        final var aHandlerChain = new HandlerExecutionChain(someOtherHandler);
+
+        when(aRequestMappingHandlerMapping.getHandler(Mockito.any()))
+                .thenReturn(aHandlerChain);
+
+        final var aIdempotencyKeyFilter = new IdempotencyKeyFilter(
+                idempotencyKeyGateway,
+                aRequestMappingHandlerMapping,
+                aHandlerExceptionResolver,
+                observationHelper
+        );
+
+        var method = IdempotencyKeyFilter.class.getDeclaredMethod("getHandlerMethod", HttpServletRequest.class);
+        method.setAccessible(true);
+        var result = method.invoke(aIdempotencyKeyFilter, aRequest);
+
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    void shouldReturnTrueWhenMethodAndClassAreAnnotated() throws NoSuchMethodException {
+        @RestController
+        class TestController {
+            @IdempotencyKey
+            public void testMethod() {
+            }
+        }
+
+        Method method = TestController.class.getMethod("testMethod");
+        HandlerMethod handlerMethod = new HandlerMethod(new TestController(), method);
+
+        boolean result = invokeIsIdempotencyKeyAnnotated(handlerMethod);
+        Assertions.assertTrue(result);
+    }
+
+    @Test
+    void shouldReturnFalseWhenMethodIsAnnotatedButClassIsNot() throws NoSuchMethodException {
+        class TestController {
+            @IdempotencyKey
+            public void testMethod() {
+            }
+        }
+
+        Method method = TestController.class.getMethod("testMethod");
+        HandlerMethod handlerMethod = new HandlerMethod(new TestController(), method);
+
+        boolean result = invokeIsIdempotencyKeyAnnotated(handlerMethod);
+        Assertions.assertFalse(result);
+    }
+
+    @Test
+    void shouldReturnFalseWhenMethodIsNotAnnotatedButClassIs() throws NoSuchMethodException {
+        @RestController
+        class TestController {
+            public void testMethod() {
+            }
+        }
+
+        Method method = TestController.class.getMethod("testMethod");
+        HandlerMethod handlerMethod = new HandlerMethod(new TestController(), method);
+
+        boolean result = invokeIsIdempotencyKeyAnnotated(handlerMethod);
+        Assertions.assertFalse(result);
+    }
+
+    @Test
+    void shouldReturnFalseWhenNeitherMethodNorClassAreAnnotated() throws NoSuchMethodException {
+        class TestController {
+            public void testMethod() {
+            }
+        }
+
+        Method method = TestController.class.getMethod("testMethod");
+        HandlerMethod handlerMethod = new HandlerMethod(new TestController(), method);
+
+        boolean result = invokeIsIdempotencyKeyAnnotated(handlerMethod);
+        Assertions.assertFalse(result);
+    }
+
+    private boolean invokeIsIdempotencyKeyAnnotated(HandlerMethod handlerMethod) {
+        final var filter = new IdempotencyKeyFilter(
+                idempotencyKeyGateway,
+                mock(RequestMappingHandlerMapping.class),
+                mock(HandlerExceptionResolver.class),
+                observationHelper
+        );
+        return Boolean.TRUE.equals(ReflectionTestUtils.invokeMethod(filter, "isIdempotencyKeyAnnotated", handlerMethod));
     }
 }

--- a/infrastructure/src/test/java/com/kaua/events/platform/infrastructure/services/rsakey/FileRsaKeyProviderTest.java
+++ b/infrastructure/src/test/java/com/kaua/events/platform/infrastructure/services/rsakey/FileRsaKeyProviderTest.java
@@ -1,0 +1,122 @@
+package com.kaua.events.platform.infrastructure.services.rsakey;
+
+import com.kaua.events.platform.domain.UnitTest;
+import com.kaua.events.platform.infrastructure.utils.PemFileUtils;
+import com.kaua.events.platform.infrastructure.utils.RsaKeyPair;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+
+class FileRsaKeyProviderTest extends UnitTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private FileRsaKeyProvider rsaKeyProvider;
+
+    private static MockedStatic<PemFileUtils> pemUtilsMock;
+
+    private static RsaKeyPair rsaKeyPair;
+
+    @BeforeAll
+    static void setupClass() {
+        pemUtilsMock = mockStatic(PemFileUtils.class);
+        rsaKeyPair = new RsaKeyPair(
+                mock(RSAPrivateKey.class),
+                mock(RSAPublicKey.class)
+        );
+    }
+
+    @AfterAll
+    static void tearDownClass() {
+        pemUtilsMock.close();
+    }
+
+    @BeforeEach
+    void setUp() {
+        rsaKeyProvider = new FileRsaKeyProvider(tempDir);
+    }
+
+    @Test
+    void shouldLoadPrivateKey() {
+        // given
+        String keyName = "mykey";
+        Path privatePath = tempDir.resolve(keyName + "-private.pem");
+
+        pemUtilsMock.when(() -> PemFileUtils.readOrCreateKeyPair(privatePath))
+                .thenReturn(rsaKeyPair);
+
+        // when
+        RSAPrivateKey result = rsaKeyProvider.getPrivateKey(keyName);
+
+        // then
+        Assertions.assertNotNull(result);
+        Assertions.assertSame(rsaKeyPair.privateKey(), result);
+
+        // make sure it was cached
+        RSAPrivateKey cached = rsaKeyProvider.getPrivateKey(keyName);
+        Assertions.assertSame(result, cached); // same instance, from cache
+    }
+
+    @Test
+    void shouldLoadPublicKey() {
+        // given
+        String keyName = "mykey";
+        Path publicPath = tempDir.resolve(keyName + "-public.pem");
+
+        pemUtilsMock.when(() -> PemFileUtils.readOrCreateKeyPair(publicPath))
+                .thenReturn(rsaKeyPair);
+
+        // when
+        RSAPublicKey result = rsaKeyProvider.getPublicKey(keyName);
+
+        // then
+        Assertions.assertNotNull(result);
+        Assertions.assertSame(rsaKeyPair.publicKey(), result);
+
+        // make sure it was cached
+        RSAPublicKey cached = rsaKeyProvider.getPublicKey(keyName);
+        Assertions.assertSame(result, cached);
+    }
+
+    @Test
+    void shouldCreateBasePathWithoutMock() {
+        // given
+        Path newDir = tempDir.resolve("real-new-dir");
+
+        Assertions.assertFalse(Files.exists(newDir));
+
+        // when
+        FileRsaKeyProvider provider = new FileRsaKeyProvider(newDir);
+
+        // then
+        Assertions.assertNotNull(provider);
+        Assertions.assertTrue(Files.exists(newDir));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCreateBasePathFails() {
+        // given
+        Path path = tempDir.resolve("fail-dir");
+
+        try (MockedStatic<Files> filesMock = mockStatic(Files.class)) {
+            filesMock.when(() -> Files.exists(path)).thenReturn(false);
+            filesMock.when(() -> Files.createDirectories(path))
+                    .thenThrow(new IOException("Simulated failure"));
+
+            // when + then
+            RuntimeException exception = Assertions.assertThrows(RuntimeException.class, () -> new FileRsaKeyProvider(path));
+
+            Assertions.assertTrue(exception.getMessage().contains("Could not create base path"));
+        }
+    }
+}

--- a/infrastructure/src/test/java/com/kaua/events/platform/infrastructure/utils/PemFileUtilsTest.java
+++ b/infrastructure/src/test/java/com/kaua/events/platform/infrastructure/utils/PemFileUtilsTest.java
@@ -1,0 +1,172 @@
+package com.kaua.events.platform.infrastructure.utils;
+
+import com.kaua.events.platform.domain.UnitTest;
+import com.kaua.events.platform.infrastructure.constants.Constants;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+
+class PemFileUtilsTest extends UnitTest {
+
+    @TempDir
+    private Path tempDir;
+
+    private Path keyPath;
+    private Path privatePath;
+    private Path publicPath;
+
+    @BeforeEach
+    void setUp() {
+        keyPath = tempDir.resolve("testkey" + Constants.RSA_KEY_PRIVATE_FILE);
+        privatePath = tempDir.resolve("testkey" + Constants.RSA_KEY_PRIVATE_FILE);
+        publicPath = tempDir.resolve("testkey" + Constants.RSA_KEY_PUBLIC_FILE);
+    }
+
+    @Test
+    void shouldGenerateKeysIfNotExists() throws Exception {
+        Files.deleteIfExists(privatePath);
+        Files.deleteIfExists(publicPath);
+
+        RsaKeyPair pair = PemFileUtils.readOrCreateKeyPair(keyPath);
+
+        Assertions.assertNotNull(pair);
+        Assertions.assertTrue(Files.exists(privatePath));
+        Assertions.assertTrue(Files.exists(publicPath));
+    }
+
+    @Test
+    void shouldGenerateKeysIfBothFilesAreMissing() throws IOException {
+        Files.deleteIfExists(privatePath);
+        Files.deleteIfExists(publicPath);
+
+        RsaKeyPair pair = PemFileUtils.readOrCreateKeyPair(keyPath);
+        Assertions.assertNotNull(pair);
+    }
+
+    @Test
+    void shouldGenerateKeysIfPrivateFileIsMissingOnly() throws Exception {
+        Files.deleteIfExists(privatePath);
+        Files.writeString(publicPath, generateValidPublicPem());
+
+        RsaKeyPair pair = PemFileUtils.readOrCreateKeyPair(keyPath);
+        Assertions.assertNotNull(pair);
+    }
+
+    @Test
+    void shouldGenerateKeysIfPublicFileIsMissingOnly() throws Exception {
+        Files.writeString(privatePath, generateValidPrivatePem());
+        Files.deleteIfExists(publicPath);
+
+        RsaKeyPair pair = PemFileUtils.readOrCreateKeyPair(keyPath);
+        Assertions.assertNotNull(pair);
+    }
+
+    @Test
+    void shouldReadKeysIfBothFilesExist() throws Exception {
+        Files.writeString(privatePath, generateValidPrivatePem());
+        Files.writeString(publicPath, generateValidPublicPem());
+
+        RsaKeyPair pair = PemFileUtils.readOrCreateKeyPair(keyPath);
+        Assertions.assertNotNull(pair);
+    }
+
+    @Test
+    void shouldReadKeysIfExists() throws Exception {
+        generateAndWriteKeyPair(privatePath, publicPath);
+
+        RsaKeyPair pair = PemFileUtils.readOrCreateKeyPair(keyPath);
+
+        Assertions.assertNotNull(pair);
+        Assertions.assertTrue(Files.exists(privatePath));
+        Assertions.assertTrue(Files.exists(publicPath));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenPrivateFileIsInvalid() throws Exception {
+        Files.writeString(privatePath, "invalid private key");
+        Files.writeString(publicPath, generateValidPublicPem());
+
+        UncheckedIOException exception = Assertions.assertThrows(UncheckedIOException.class, () -> {
+            PemFileUtils.readOrCreateKeyPair(keyPath);
+        });
+
+        Assertions.assertTrue(exception.getMessage().contains("Failed to load/create RSA key pair"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenPublicFileIsInvalid() throws Exception {
+        Files.writeString(privatePath, generateValidPrivatePem());
+        Files.writeString(publicPath, "invalid public key");
+
+        UncheckedIOException exception = Assertions.assertThrows(UncheckedIOException.class, () -> {
+            PemFileUtils.readOrCreateKeyPair(keyPath);
+        });
+
+        Assertions.assertTrue(exception.getMessage().contains("Failed to load/create RSA key pair"));
+    }
+
+    @Test
+    void shouldThrowExceptionIfWriteFails() {
+        Path invalidPath = Paths.get("/invalid/testkey" + Constants.RSA_KEY_PRIVATE_FILE);
+
+        UncheckedIOException exception = Assertions.assertThrows(UncheckedIOException.class, () -> {
+            PemFileUtils.readOrCreateKeyPair(invalidPath);
+        });
+
+        Assertions.assertTrue(exception.getMessage().contains("Failed to load/create RSA key pair"));
+    }
+
+    // Helpers
+
+    private static void generateAndWriteKeyPair(Path privatePath, Path publicPath) throws Exception {
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
+        gen.initialize(2048);
+        KeyPair pair = gen.generateKeyPair();
+
+        writePem(privatePath, "PRIVATE KEY", pair.getPrivate().getEncoded());
+        writePem(publicPath, "PUBLIC KEY", pair.getPublic().getEncoded());
+    }
+
+    private static void writePem(Path path, String type, byte[] encoded) throws IOException {
+        String base64 = Base64.getEncoder().encodeToString(encoded);
+        String pem = "-----BEGIN " + type + "-----\n" +
+                base64 + "\n" +
+                "-----END " + type + "-----\n";
+
+        Files.writeString(path, pem, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+    }
+
+    private static String generateValidPrivatePem() throws Exception {
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
+        gen.initialize(2048);
+        KeyPair pair = gen.generateKeyPair();
+
+        return encodeToPem("PRIVATE KEY", pair.getPrivate().getEncoded());
+    }
+
+    private static String generateValidPublicPem() throws Exception {
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
+        gen.initialize(2048);
+        KeyPair pair = gen.generateKeyPair();
+
+        return encodeToPem("PUBLIC KEY", pair.getPublic().getEncoded());
+    }
+
+    private static String encodeToPem(String type, byte[] encoded) {
+        String base64 = Base64.getEncoder().encodeToString(encoded);
+        return "-----BEGIN " + type + "-----\n" +
+                base64 + "\n" +
+                "-----END " + type + "-----\n";
+    }
+}


### PR DESCRIPTION
## Descrição

Foi adicionado a geração de rsa keys com uma interface para deixar extensível no futuro, hoje no momento ele salva e lê localmente as keys, também foi configurada para o spring security usar elas.

## Mudanças Propostas

- Adicionado o FileRsaKeyProvider
- Adicionado o rsa keys provider no spring security decode e encode

## Testes Realizados

Testes de unidade

## Cobertura de Testes

O minimo é 95%, hoje esta em 98%

## Problemas Conhecidos

N/A

## Checklist

- [X] Todos os testes passaram com sucesso.
- [X] A cobertura de testes está acima da porcentagem mínima exigida.
